### PR TITLE
fix filtering of locations and markers

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -64,6 +64,7 @@ class App extends React.Component {
      * @returns void
      */
     public selectMarker = (id: number) => {
+        this.filterStores(id);
         this.setState({ selectedStoreId: id });
     }
 
@@ -167,7 +168,8 @@ class App extends React.Component {
                                 <ErrorBoundary>
                                     <StoreList
                                         selectStore={this.filterStores}
-                                        stores={this.stores}
+                                        stores={this.state.stores}
+                                        selectedStoreId={this.state.selectedStoreId}
                                     />
                                 </ErrorBoundary>
 
@@ -187,7 +189,7 @@ class App extends React.Component {
                             loadingElement={<div style={{ height: `100%` }} />}
                             containerElement={<div style={{ width: '100vw', height: `100vh` }} />}
                             mapElement={<div style={{ height: `100%` }} />}
-                            stores={this.stores}
+                            stores={this.state.stores}
                             selectedStoreId={this.state.selectedStoreId}
                             selectMarker={this.selectMarker}
                             deselectMarker={this.deselectMarker}

--- a/src/components/StoreList.tsx
+++ b/src/components/StoreList.tsx
@@ -5,14 +5,25 @@ import './StoreList.css';
 
 export interface IProps {
     stores: IFogStore[];
+    selectedStoreId: number;
     selectStore: (id: number) => void;
 }
 
 const StoreList: React.SFC<IProps> = (props: IProps) => {
+    let filteredStores;
+    
+    if (props.selectedStoreId) {
+       filteredStores = props.stores.filter((store: any) => {
+        return store.id === props.selectedStoreId;
+        });
+    } else {
+        filteredStores = props.stores;
+    }
+
     return (
         <nav aria-labelledby='filtered-stores' className='store-list-container' id='store-list-nav'>
             <ul id='filtered-stores' aria-expanded={true} role='menu' className='store-list'>
-                {props.stores.map((store: any, index: number) => {
+                {filteredStores.map((store: any, index: number) => {
                     return (
                         <li
                             key={index}


### PR DESCRIPTION
When a location is selected from the sidebar list of locations or a marker is selected on the map, both the list of locations and the markers are filtered to only show that location.

Fixes #15 